### PR TITLE
Add booking model with status enum and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/models/Booking.js
+++ b/models/Booking.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const STATUS = ['PENDING', 'CONFIRMED', 'FULLY_BOOKED', 'CANCELLED'];
+
+const BookingSchema = new mongoose.Schema({
+  date: { type: Date, required: true },
+  time_from: { type: String, required: true },
+  time_to: { type: String, required: true },
+  status: { type: String, enum: STATUS, default: 'PENDING' },
+  client_id: { type: mongoose.Schema.Types.ObjectId, required: true, ref: 'Client' },
+  agency_id: { type: mongoose.Schema.Types.ObjectId, required: true, ref: 'Agency' },
+  notes: { type: String }
+});
+
+module.exports = mongoose.model('Booking', BookingSchema);
+module.exports.STATUS = STATUS;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "booking-backend",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "seed": "node seed/bookingSeed.js",
+    "test": "echo \"No tests configured\""
+  },
+  "dependencies": {
+    "mongoose": "^7.0.0"
+  }
+}

--- a/seed/bookingSeed.js
+++ b/seed/bookingSeed.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+const Booking = require('../models/Booking');
+
+const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/booking';
+
+async function seed() {
+  try {
+    await mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true });
+
+    await Booking.deleteMany({});
+
+    await Booking.insertMany([
+      {
+        date: new Date('2024-09-01'),
+        time_from: '10:00',
+        time_to: '12:00',
+        status: 'CONFIRMED',
+        client_id: new mongoose.Types.ObjectId(),
+        agency_id: new mongoose.Types.ObjectId(),
+        notes: 'Initial confirmed booking'
+      },
+      {
+        date: new Date('2024-09-02'),
+        time_from: '14:00',
+        time_to: '16:00',
+        status: 'PENDING',
+        client_id: new mongoose.Types.ObjectId(),
+        agency_id: new mongoose.Types.ObjectId(),
+        notes: 'Initial pending booking'
+      }
+    ]);
+
+    console.log('Seeding completed');
+  } catch (err) {
+    console.error('Seeding error', err);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+seed();


### PR DESCRIPTION
## Summary
- define Booking mongoose model with date, time range, status, client and agency fields
- introduce status enum (PENDING, CONFIRMED, FULLY_BOOKED, CANCELLED)
- add seed script to populate sample bookings

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mongoose)*
- `npm test`
- `node seed/bookingSeed.js` *(fails: Cannot find module 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_68be1676891c832fabcb31763a910871